### PR TITLE
楽天apiにapplication_id付与

### DIFF
--- a/config/initializers/rakuten.rb
+++ b/config/initializers/rakuten.rb
@@ -1,1 +1,5 @@
-RWS_APPLICATION_ID = ENV['RWS_APPLICATION_ID']
+# RWS_APPLICATION_ID = ENV['RWS_APPLICATION_ID']
+
+RakutenWebService.configure do |c|
+    c.application_id = ENV['RWS_APPLICATION_ID'] # 環境変数から読み込む
+end


### PR DESCRIPTION
- [x] config/initializers/rakuten.rbの書き方変更
- [x] application_id付与する形に変更
```
RakutenWebService.configure do |c|
    c.application_id = ENV['RWS_APPLICATION_ID'] # 環境変数から読み込む
end
```