### PR TITLE
Google certification

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -7,29 +7,22 @@ class OauthsController < ApplicationController
   end
 
   def callback
-    # binding.pry
     provider = auth_params[:provider]
-    # Rails.logger.debug "Provider: #{provider}"
 
     if auth_params[:code].blank?
-      Rails.logger.error "Missing required parameter: code"
       flash[:alert] = "Google認証がキャンセルされました"
       redirect_to root_path and return
     end
 
     # 既存のユーザーをプロバイダ情報を元に検索し、存在すればログイン
     if (@user = login_from(provider))
-      # Rails.logger.debug "User logged in: #{@user.id}"
-      # binding.pry
       redirect_to tackles_path, success: "#{provider.titleize}アカウントでログインしました"
     else
       begin
-        # Rails.logger.debug "User not found, creating new user from #{provider}"
         # ユーザーが存在しない場合はプロバイダ情報を元に新規ユーザーを作成し、ログイン
         signup_and_login(provider)
         redirect_to tackles_path, success: "#{provider.titleize}アカウントでログインしました"
       rescue => e
-        # Rails.logger.error "Error during login from #{provider}: #{e.message}"
         flash.now[:alert] = "#{provider.titleize}アカウントでのログインに失敗しました"
         redirect_to root_path
       end
@@ -40,7 +33,6 @@ class OauthsController < ApplicationController
 
   def auth_params
     params.permit(:code, :provider, :scope, :authuser, :prompt)
-    # params.permit(:code, :provider, :error, :state)
   end
 
   def signup_and_login(provider)

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -7,8 +7,9 @@ class OauthsController < ApplicationController
   end
 
   def callback
+    # binding.pry
     provider = auth_params[:provider]
-    Rails.logger.debug "Provider: #{provider}"
+    # Rails.logger.debug "Provider: #{provider}"
 
     if auth_params[:code].blank?
       Rails.logger.error "Missing required parameter: code"
@@ -18,6 +19,8 @@ class OauthsController < ApplicationController
 
     # 既存のユーザーをプロバイダ情報を元に検索し、存在すればログイン
     if (@user = login_from(provider))
+      # Rails.logger.debug "User logged in: #{@user.id}"
+      # binding.pry
       redirect_to tackles_path, success: "#{provider.titleize}アカウントでログインしました"
     else
       begin
@@ -42,6 +45,7 @@ class OauthsController < ApplicationController
 
   def signup_and_login(provider)
     @user = create_from(provider)
+    Rails.logger.debug "Created user: #{@user.inspect}"
     reset_session
     auto_login(@user)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :tackles, dependent: :destroy
+  has_many :authentications, :dependent => :destroy
+  accepts_nested_attributes_for :authentications
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -163,7 +163,7 @@ Rails.application.config.sorcery.configure do |config|
   #API設定で承認済みのリダイレクトURIとして登録したurlを設定
   config.google.callback_url = Settings.sorcery[:google_callback_url]
   #外部サービスから取得したユーザー情報をUserモデルの指定した属性にマッピング
-  config.google.user_info_mapping = {:email => "email", :username => "name"}
+  config.google.user_info_mapping = { email: "email", name: "name" }
   # config.google.scope = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
   #
   # For Microsoft Graph, the key will be your App ID, and the secret will be your app password/public key.

--- a/db/migrate/20240608055509_change_users_crypted_password_and_salt.rb
+++ b/db/migrate/20240608055509_change_users_crypted_password_and_salt.rb
@@ -1,0 +1,6 @@
+class ChangeUsersCryptedPasswordAndSalt < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :users, :crypted_password, true
+    change_column_null :users, :salt, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_06_015857) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_08_055509) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -110,7 +110,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_06_015857) do
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
-    t.string "crypted_password", null: false
+    t.string "crypted_password"
     t.string "salt"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
google認証で、userモデルのカラムと制約の変更を実施。

socery.rb　usernameカラムは存在しないので変更
- config.google.user_info_mapping = { email: "email", name: "name" }

google APIの制約と異なるためcrypted_passwordとsaltの制約を変更
- crypted_password, true
- :salt, true