### PR TITLE
釣り具提案機能改善

### DIFF
--- a/app/services/openai_service.rb
+++ b/app/services/openai_service.rb
@@ -10,6 +10,8 @@ class OpenaiService
       予算: #{params[:budget]}
       釣りの場所: #{params[:location]}
       釣りの種類: #{params[:method]}
+      提案する釣り具の種類: #{params[:tackle_type]}
+      提案するメーカー: #{params[:tackle_maker]}
       釣りの経験レベル: #{params[:skill_level]}
     PROMPT
 

--- a/app/views/fishing_gears/index.html.erb
+++ b/app/views/fishing_gears/index.html.erb
@@ -25,6 +25,14 @@
                 <%= f.label :skill_level, t('fishing_gears.index.skill_level'), class: 'text-black font-bold text-xl w-[120px] text-right pr-4' %>
                 <%= f.select :skill_level, options_for_select(['初心者', '中級者', '上級者'], params[:skill_level]), {}, class: 'flex-grow shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline border-blue border-2' %>
             </div>
+            <div class="flex items-center">
+                <%= f.label :tackle_type, t('fishing_gears.index.tackle_type'), class: 'text-black font-bold text-xl w-[120px] text-right pr-4' %>
+                <%= f.select :tackle_type, options_for_select(['ロッド', 'リール', 'ライン', 'ルアー', 'タックル一式'], params[:tackle_type]), {}, class: 'flex-grow shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline border-blue border-2' %>
+            </div>
+            <div class="flex items-center">
+                <%= f.label :tackle_maker, t('fishing_gears.index.tackle_maker'), class: 'text-black font-bold text-xl w-[120px] text-right pr-4' %>
+                <%= f.select :tackle_maker, options_for_select(['全て','シマノ', 'ダイワ', 'アブガルシア', 'がまかつ', 'テイルフォーク', 'オリムピック', 'メジャークラフト'], params[:tackle_maker]), {}, class: 'flex-grow shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline border-blue border-2' %>
+            </div>
             <div class="flex items-center justify-center">
                 <%= f.submit t('fishing_gears.index.submit'), class: 'underline underline-offset-2 text-link font-bold px-4 py-2 ml-8 bg-orange text-white rounded no-underline cursor-pointer hover:opacity-70' %>
             </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -133,6 +133,8 @@ ja:
       location: 釣りの場所
       method: 釣りの種類
       skill_level: 釣りの経験レベル
+      tackle_type: 釣り具の種類
+      tackle_maker: メーカー
       submit: 提案を受ける
   fishing_plans:
     index:


### PR DESCRIPTION
以下を施してさらに精度を上げました
- ユーザーの入力情報を追加
  - 提案する釣り具の種類:tackle_type
  -  提案するメーカー:tackle_maker
- コントローラーにてプロンプトに表示されている商品名「」からキーワードをとって検索されるように設定
より合致する商品が表示される